### PR TITLE
feat: Add container mode support to bypass host executable validation

### DIFF
--- a/lib/MTT/Test/Specify/Simple.pm
+++ b/lib/MTT/Test/Specify/Simple.pm
@@ -138,6 +138,11 @@ sub Specify {
                 $ok = 1;
             } elsif (-x $t) {
                 $ok = 1;
+            } elsif ($ENV{MTT_CONTAINER_MODE}) {
+                # In container mode, assume executables exist in the container
+                # even if they don't exist on the host
+                Debug("   Container mode: assuming $t exists in container\n");
+                $ok = 1;
             }
             # If it's not good, print it out, because that's
             # *probably* unexpected.  It might not be unexpected, and


### PR DESCRIPTION
When MTT_CONTAINER_MODE environment variable is set, MTT will assume that test executables exist in the container even if they are not found on the host system. This allows running container-only tests without requiring the test binaries to be present on the host.

MTT test report for OSU test suite (test failures are expected): http://hpcweb.lab.mtl.com/hpc/mtr_scrap/users/artemry/scratch/ucx-enroot/20251126_173026_3676487_8006_funk10/

Bare-metal MTT run on funk:
http://hpcweb.lab.mtl.com/hpc/mtr_scrap/users/artemry/scratch/ucx_ompi/20251107_233618_361308_5704_funk08/ 