### PR TITLE
Container mode support for MTT (Pyxis/Enroot)

### DIFF
--- a/lib/MTT/MPI/Get/AlreadyInstalled.pm
+++ b/lib/MTT/MPI/Get/AlreadyInstalled.pm
@@ -43,24 +43,28 @@ sub Get {
 
     # If they do not, search the user's PATH for an MPI
     if (! -e $installdir) {
-        Warning("A non-existent \"installdir\" parameter was provided,\n" .
-                "I will search your path for an MPI ...\n")
-            if (defined($installdir));
+        if ($ENV{MTT_CONTAINER_MODE} && defined($installdir)) {
+            Verbose("   Container mode: assuming $installdir exists in container\n");
+        } else {
+            Warning("A non-existent \"installdir\" parameter was provided,\n" .
+                    "I will search your path for an MPI ...\n")
+                if (defined($installdir));
 
-        my $program = FindProgram(qw(mpicc mpiexec mpirun));
+            my $program = FindProgram(qw(mpicc mpiexec mpirun));
 
-        # Fail if we did not find an MPI
-        if (! -e $program) {
-            my $error = "I did not find an MPI in your PATH.\n";
-            $ret->{result_message} = "Failed; $error";
-            $ret->{test_result} = MTT::Values::FAIL;
-            return $ret;
+            # Fail if we did not find an MPI
+            if (! -e $program) {
+                my $error = "I did not find an MPI in your PATH.\n";
+                $ret->{result_message} = "Failed; $error";
+                $ret->{test_result} = MTT::Values::FAIL;
+                return $ret;
+            }
+
+            $installdir = dirname($program);
+
+            # Protect against this common user error
+            $installdir =~ s/bin\/?$//;
         }
-
-        $installdir = dirname($program);
-
-        # Protect against this common user error
-        $installdir =~ s/bin\/?$//;
     }
     Verbose("   Using MPI in: $installdir\n");
 

--- a/lib/MTT/Test/RunEngine.pm
+++ b/lib/MTT/Test/RunEngine.pm
@@ -301,6 +301,8 @@ sub _run_one_np {
     my $name;
     if (-e $MTT::Test::Run::test_executable) {
         $name = basename($MTT::Test::Run::test_executable);
+    } elsif ($ENV{MTT_CONTAINER_MODE}) {
+        $name = basename($MTT::Test::Run::test_executable);
     }
     $run->{name} = $name;
 
@@ -385,6 +387,8 @@ sub _run_one_test {
 
     my $basename = $MTT::Test::Run::test_executable;
     if (-e $MTT::Test::Run::test_executable) {
+        $basename = basename($MTT::Test::Run::test_executable);
+    } elsif ($ENV{MTT_CONTAINER_MODE}) {
         $basename = basename($MTT::Test::Run::test_executable);
     }
 

--- a/lib/MTT/Values/Functions.pm
+++ b/lib/MTT/Values/Functions.pm
@@ -3654,7 +3654,9 @@ sub cluster_name
 {
     my $clust_name;
 
-    if (slurm_job()) {
+    if ($ENV{SLURM_CLUSTER_NAME}) {
+        $clust_name = $ENV{SLURM_CLUSTER_NAME};
+    } elsif (slurm_job()) {
         $clust_name = `squeue -h -j $ENV{SLURM_JOB_ID} -o %P`;
     } else {
         $clust_name = `hostname`;


### PR DESCRIPTION
## Summary

Enables running MTT test suites inside Enroot/Pyxis containers on HPC clusters, including external clusters (e.g. Pre-Tyche) that lack an internal module stack and MTA.

- **Skip host-side installdir check in container mode**: `AlreadyInstalled` MPI Get no longer fails when `alreadyinstalled_dir` (e.g. `/opt/hpcx`) only exists inside the container. Gated on `MTT_CONTAINER_MODE`.
- **Keep HTML reporter registered when MTA is unavailable**: on clusters without a local MTA, `MTT::Mail::Init` fails; previously the HTML reporter returned 0 at Init and never wrote reports. Now disables email but still generates HTML on disk.
- **Fix container test dedup collision** caused by undef basename.
- **Fix `cluster_name()`** reporting partition instead of cluster name.

## Test plan

- [x] Container tests execute end-to-end on Pre-Tyche (ucx-enroot suite, 500+ test steps)
- [] HTML reports generated on disk without MTA (validating in this run)
- [x] Host-side (bare metal) runs unaffected — container changes are gated on `MTT_CONTAINER_MODE`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTML reporting now continues even when email initialization fails, instead of stopping entirely.

* **New Features**
  * Improved container environment support with better handling of test executable paths and MPI discovery.
  * Enhanced cluster name detection using SLURM environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->